### PR TITLE
Initialize the RubyVM::JIT module.

### DIFF
--- a/inits.c
+++ b/inits.c
@@ -53,6 +53,7 @@ rb_call_inits(void)
     CALL(GC);
     CALL(Enumerator);
     CALL(VM);
+    CALL(JIT);
     CALL(ISeq);
     CALL(Thread);
     CALL(process);

--- a/test/test_jit.rb
+++ b/test/test_jit.rb
@@ -1,0 +1,21 @@
+require 'test/unit'
+
+
+class JITModuleTest < Test::Unit::TestCase 
+
+   def addone(x)
+      return x+1
+   end
+
+   def test_jit_control
+      am = method(:addone)
+      # No testing occurs in this module unless the jit exists. 
+      if RubyVM::JIT::exists?
+         assert_equal(false,RubyVM::JIT::compiled?(am) )
+         assert_equal(true, RubyVM::JIT::compile(am) )
+         assert_equal(true, RubyVM::JIT::compiled?(am) )
+      end
+   end
+
+end
+


### PR DESCRIPTION
This module adds a Ruby interface to the OMR JIT.

This allows code like the following:

```
   def addone(x)
      return x+1
   end

   am = method(:addone)

   if RubyVM::JIT::exists?
      puts "Compiled? #{RubyVM::JIT::compiled? am}"
      puts "Compile:  #{RubyVM::JIT::compile am}"
      puts "Compiled? #{RubyVM::JIT::compiled? am}"
   else
      puts "JIT not active!"
   end
```

This includes a JIT unit test, which has the bare minimum to exercise
the JIT interface.

The module is supported, even when configured --without-omr-jit,
to allow more use.
