### PR TITLE
Add JIT command line option.

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -18,6 +18,7 @@
 #include "ruby/vm.h"
 #include "vm_core.h"
 #include "probes_helper.h"
+#include "jit.h"
 
 NORETURN(void rb_raise_jump(VALUE, VALUE));
 
@@ -230,6 +231,8 @@ ruby_cleanup(volatile int ex)
     return sysex;
 }
 
+extern jit_globals_t jit_globals; 
+
 static int
 ruby_exec_internal(void *n)
 {
@@ -238,6 +241,12 @@ ruby_exec_internal(void *n)
     rb_thread_t *th = GET_THREAD();
 
     if (!n) return 0;
+
+#ifdef JIT_OMR
+    if (!GET_VM()->jit) { 
+      vm_jit_init(GET_VM(), jit_globals);
+    }
+#endif
 
     TH_PUSH_TAG(th);
     if ((state = EXEC_TAG()) == 0) {


### PR DESCRIPTION
ruby -J<omr jit options> will now activate the JIT. In cases where the
enviornment variabel is also specified, the environment variable will
win, but produce a warning.

This changes the startup sequence a bit, in order to compensate for the
fact that options processing happens after Init_BareVM.

Fixes Issue #25

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>