### PR TITLE
Revive Inliner support.

### DIFF
--- a/jit.h
+++ b/jit.h
@@ -76,10 +76,8 @@ struct jit_callbacks_struct {
    void                 (*rb_bug_f)                     (const char *, ...);
    VALUE                (*vm_exec_core_f)               (rb_thread_t *th, VALUE initial);
    const char *         (*rb_class2name_f)              (VALUE klass); 
-   /*
-   void                 (*vm_send_woblock_jit_inline_frame_f)(rb_thread_t *th, CALL_INFO ci, VALUE recv);
-   VALUE                (*vm_send_woblock_inlineable_guard_f)(CALL_INFO ci, VALUE klass);
-   */
+   void                 (*vm_send_woblock_jit_inline_frame_f)(rb_thread_t *th, CALL_INFO ci, CALL_CACHE cc, const rb_iseq_t* iseq, VALUE recv);
+   VALUE                (*vm_send_woblock_inlineable_guard_f)(rb_serial_t method_state, rb_serial_t class_serial, VALUE klass);
    void                 (*rb_threadptr_execute_interrupts_f) (rb_thread_t *th, int blocking_timing);
 #ifdef OMR_RUBY_VALID_CLASS
     int                 (*ruby_omr_is_valid_object_f)   (VALUE object);
@@ -89,7 +87,7 @@ struct jit_callbacks_struct {
     VALUE               (*rb_str_freeze_f)              (VALUE);
     VALUE               (*rb_ivar_set_f)                (VALUE, ID, VALUE);
     OFFSET              (*vm_compute_case_dest_f)       (CDHASH,OFFSET,VALUE);  
-
+    const rb_iseq_t *   (*def_iseq_ptr_f)               (rb_method_definition_t *def);
 
 };
 

--- a/rbjitglue/ruby/control/RubyJit.cpp
+++ b/rbjitglue/ruby/control/RubyJit.cpp
@@ -130,10 +130,8 @@ initializeAllHelpers(struct rb_vm_struct *vm, TR_RubyJitConfig *jitConfig)
    initHelper(vm_invokeblock);
    initHelper(rb_method_entry);
    initHelper(rb_class_of);
-   /*
    initHelper(vm_send_woblock_jit_inline_frame);
    initHelper(vm_send_woblock_inlineable_guard);
-   */
    initHelper(rb_bug);
    initHelper(vm_exec_core);
 #ifdef OMR_JIT_PROFILING

--- a/rbjitglue/ruby/optimizer/Optimizer.cpp
+++ b/rbjitglue/ruby/optimizer/Optimizer.cpp
@@ -58,7 +58,6 @@ static const OptimizationStrategy rubyNoOptStrategyOpts[] =
 
 static const OptimizationStrategy rubyColdStrategyOpts[] =
    {
-   { OMR::trivialInlining                                                    },
    { OMR::rubyIlFastpather                                                   },
    { OMR::basicBlockExtension                                                },
    { OMR::localCSE                                                           },
@@ -75,7 +74,8 @@ static const OptimizationStrategy rubyColdStrategyOpts[] =
 
 static const OptimizationStrategy rubyWarmStrategyOpts[] =
    {
-   //{ rubyIlFastpather                                                   },
+   { OMR::trivialInlining                                                    },
+   { OMR::rubyIlFastpather                                                   },
    { OMR::basicBlockExtension                                                },
    { OMR::localCSE                                                           },
    { OMR::treeSimplification                                                 },

--- a/rbjitglue/ruby/optimizer/RubyCallInfo.cpp
+++ b/rbjitglue/ruby/optimizer/RubyCallInfo.cpp
@@ -41,9 +41,6 @@ TR_CallSite* TR_CallSite::create(TR::TreeTop* tt,
       int32_t depth,
       bool allConsts)
    {
-   TR_ASSERT(false, "Inlining for 2.3 is intentionally disabled." ); 
-   return NULL; 
-   /* 
    TR_ResolvedMethod* lCaller = caller ? caller : symRef->getOwningMethod(comp);
    if(node->getSymbol()->castToMethodSymbol()->isHelper())
       {
@@ -98,11 +95,17 @@ TR_CallSite* TR_CallSite::create(TR::TreeTop* tt,
                node->getByteCodeInfo(),
                comp);
 
-         //Store the receiver in a temporary to be used by TR_InlinerBase::calleeTreeTopPreMergeActions.
-         //VirtualGuard splits the block up so we cannot directly reference the receiver from the callNode
-         //without BlockVerfier triggering an assertion on it.
+         //Store the receiver in a temporary to be used by
+         //TR_InlinerBase::calleeTreeTopPreMergeActions.
+         //
+         //VirtualGuard splits the block up so we cannot directly reference the
+         //receiver from the callNode without BlockVerfier triggering an
+         //assertion on it.
+         //
          //DeadStoreElimination should get rid of this temp if nobody uses it.
-         TR::Node *receiver = node->getThirdChild();
+         //
+         // This reciever index only makes sense for vm_send_without_block 
+         TR::Node *receiver = node->getChild(3);
          TR::SymbolReference *receiverTemp = TR::Node::storeToTemp(receiver, tt);
          comp->getSymRefTab()->setRubyInlinedReceiverTempSymRef(callSite, receiverTemp);
 
@@ -126,7 +129,6 @@ TR_CallSite* TR_CallSite::create(TR::TreeTop* tt,
          node->getByteCodeInfo(),
          comp);
    
-         */
    }
 
 bool
@@ -148,59 +150,55 @@ TR_Ruby_InvokeBlock_CallSite::findCallSiteTarget (TR_CallStack* callStack, TR_In
    return false;
    }
 
-// bool
-// TR_Ruby_SendSimple_CallSite::findCallSiteTarget (TR_CallStack* callStack, TR_InlinerBase* inliner)
-//    {
-//    //Landing here implies TR_RubyFE::checkInlineableWithoutInitialCalleeSymbol did all the checks and
-//    //decided this callSite was a valid inlineable target.
-// 
-//    TR::Node* node = _callNode;
-// 
-//    //Ensure that ILGen hasn't changed the children's layout we expect.
-//    TR_ASSERT(  ((node->getNumChildren() == 3) &&
-//          node->getSecondChild() &&
-//          node->getSecondChild()->getOpCodeValue() == TR::aconst), "Unexpected children in hierarchy of vm_send_without_block when creating callsite target.");
-// 
-//    rb_call_info_t *ci = (rb_call_info_t *) node->getSecondChild()->getAddress();
-// #ifdef OMR_JIT_PROFILING
-//    VALUE klass = ci->profiled_klass;
-// #else
-//    VALUE klass = Qundef; 
-// #endif
-//    VALUE actual_klass;
-//    rb_method_entry_t *me = (rb_method_entry_t*)TR_RubyFE::instance()->getJitInterface()->callbacks.rb_method_entry_f(klass, ci->mid, &actual_klass);
-//    rb_iseq_t *iseq_callee = me->def->body.iseq;
-// 
-//    int32_t len =
-//          RSTRING_LEN(iseq_callee->location.path) +
-//          (sizeof(size_t) * 3) +                // first_lineno: estimate three decimal digits per byte
-//          RSTRING_LEN(iseq_callee->location.label) +
-//          3;                                    // two colons and a null terminator
-// 
-//    char *name = (char*) comp()->trMemory()->allocateHeapMemory(len);
-//    sprintf(name, "%s:%lld:%s",
-//          (char*) RSTRING_PTR(iseq_callee->location.path),
-//          FIX2LONG(iseq_callee->location.first_lineno),
-//          (char*)RSTRING_PTR(iseq_callee->location.label));
-// 
-//    RubyMethodBlock* callee_mb = new (comp()->trPersistentMemory()) RubyMethodBlock(iseq_callee, name);
-//    ResolvedRubyMethod* callee_method = new (comp()->trPersistentMemory()) ResolvedRubyMethod(*callee_mb);
-//    TR::ResolvedMethodSymbol *calleeSymbol = TR::ResolvedMethodSymbol::createJittedMethodSymbol(comp()->trHeapMemory(), callee_method, comp());
-// 
-//    //Set ResolvedMethod and ResolvedMethodSymbol.
-//    _initialCalleeMethod = callee_method;
-//    _initialCalleeSymbol = calleeSymbol;
-// 
-//    //Add a target for inliner to process.
-//    TR_VirtualGuardSelection *guard = new (comp()->trHeapMemory()) TR_VirtualGuardSelection(TR_ProfiledGuard, TR_RubyInlineTest, (TR_OpaqueClassBlock *) klass);
-// 
-//    //Send out a callTarget
-//    addTarget(comp()->trMemory(),
-//          inliner,
-//          guard,
-//          _initialCalleeMethod,
-//          _initialCalleeMethod->classOfMethod(),
-//          heapAlloc);
-//    return true;
-//    }
+bool
+TR_Ruby_SendSimple_CallSite::findCallSiteTarget (TR_CallStack* callStack, TR_InlinerBase* inliner)
+   {
+   //Landing here implies TR_RubyFE::checkInlineableWithoutInitialCalleeSymbol did all the checks and
+   //decided this callSite was a valid inlineable target.
+
+   TR::Node* node = _callNode;
+
+   //Ensure that ILGen hasn't changed the children's layout we expect.
+   TR_ASSERT(  ((node->getNumChildren() == 4) &&
+         node->getSecondChild() &&
+         node->getSecondChild()->getOpCodeValue() == TR::aconst), "Unexpected children in hierarchy of vm_send_without_block when creating callsite target.");
+
+   CALL_INFO  ci = reinterpret_cast<CALL_INFO> (node->getSecondChild()->getAddress());
+   CALL_CACHE cc = reinterpret_cast<CALL_CACHE>(node->getThirdChild()->getAddress());
+   const rb_callable_method_entry_t *me = cc->me; 
+   const rb_iseq_t *iseq_callee = TR_RubyFE::instance()->getJitInterface()->callbacks.def_iseq_ptr_f(cc->me->def);
+
+
+   int32_t len =
+         RSTRING_LEN(iseq_callee->body->location.path) +
+         (sizeof(size_t) * 3) +                // first_lineno: estimate three decimal digits per byte
+         RSTRING_LEN(iseq_callee->body->location.label) +
+         3;                                    // two colons and a null terminator
+
+   char *name = (char*) comp()->trMemory()->allocateHeapMemory(len);
+   sprintf(name, "%s:%lld:%s",
+         (char*) RSTRING_PTR(iseq_callee->body->location.path),
+         FIX2LONG(iseq_callee->body->location.first_lineno),
+         (char*)RSTRING_PTR(iseq_callee->body->location.label));
+
+   RubyMethodBlock* callee_mb = new (comp()->trPersistentMemory()) RubyMethodBlock((rb_iseq_t*)iseq_callee, name);
+   ResolvedRubyMethod* callee_method = new (comp()->trPersistentMemory()) ResolvedRubyMethod(*callee_mb);
+   TR::ResolvedMethodSymbol *calleeSymbol = TR::ResolvedMethodSymbol::createJittedMethodSymbol(comp()->trHeapMemory(), callee_method, comp());
+
+   //Set ResolvedMethod and ResolvedMethodSymbol.
+   _initialCalleeMethod = callee_method;
+   _initialCalleeSymbol = calleeSymbol;
+
+   //Add a target for inliner to process.
+   TR_VirtualGuardSelection *guard = new (comp()->trHeapMemory()) TR_VirtualGuardSelection(TR_ProfiledGuard, TR_RubyInlineTest, (TR_OpaqueClassBlock *) NULL /* Not needed */);
+
+   //Send out a callTarget
+   addTarget(comp()->trMemory(),
+         inliner,
+         guard,
+         _initialCalleeMethod,
+         _initialCalleeMethod->classOfMethod(),
+         heapAlloc);
+   return true;
+   }
 

--- a/rbjitglue/ruby/optimizer/RubyInliner.hpp
+++ b/rbjitglue/ruby/optimizer/RubyInliner.hpp
@@ -30,7 +30,7 @@ class InlinerUtil: public OMR_InlinerUtil
    public:
       InlinerUtil(TR::Compilation *comp);
    protected:
-      virtual void calleeTreeTopPreMergeActions(TR::ResolvedMethodSymbol *calleeResolvedMethodSymbol, TR_CallSite* callSite);
+      virtual void calleeTreeTopPreMergeActions(TR::ResolvedMethodSymbol *calleeResolvedMethodSymbol, TR_CallTarget* callTarget);
    };
 
 }

--- a/rbjitglue/ruby/optimizer/RubyTrivialInliner.hpp
+++ b/rbjitglue/ruby/optimizer/RubyTrivialInliner.hpp
@@ -35,8 +35,8 @@ class TrivialInliner : public TR::Optimization
       virtual int32_t perform();
 
       virtual bool         shouldPerform() { 
-         static auto * enableInliner = feGetEnv("RUBY_ENABLE_INLINER"); 
-         return enableInliner; 
+         static auto * disableInliner = feGetEnv("RUBY_DISABLE_INLINER"); 
+         return !disableInliner; 
       } 
 
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -1232,7 +1232,7 @@ VM_BH_ISEQ_BLOCK_P(VALUE block_handler)
 {
     if ((block_handler & 0x03) == 0x01) {
 #if VM_CHECK_MODE > 0
-	struct rb_captured_block *captured = VM_TAGGED_PTR_REF(block_handler, 0x03);
+	struct rb_captured_block *captured = (struct rb_captured_block*)VM_TAGGED_PTR_REF(block_handler, 0x03);
 	VM_ASSERT(RB_TYPE_P(captured->code.val, T_IMEMO));
 	VM_ASSERT(imemo_type(captured->code.val) == imemo_iseq);
 #endif
@@ -1264,7 +1264,7 @@ VM_BH_IFUNC_P(VALUE block_handler)
 {
     if ((block_handler & 0x03) == 0x03) {
 #if VM_CHECK_MODE > 0
-	struct rb_captured_block *captured = (void *)(block_handler & ~0x03);
+	struct rb_captured_block *captured = (struct rb_captured_block *)(block_handler & ~0x03);
 	VM_ASSERT(RB_TYPE_P(captured->code.val, T_IMEMO));
 	VM_ASSERT(imemo_type(captured->code.val) == imemo_ifunc);
 #endif

--- a/vm_jit.c
+++ b/vm_jit.c
@@ -14,6 +14,7 @@
 
 /* Forward declare functions */
 VALUE rb_reg_new_ary(VALUE ary, int options);
+const rb_iseq_t * def_iseq_ptr(rb_method_definition_t *def);
 
 #define JIT_DEFAULT_COUNT 1000
 
@@ -140,10 +141,8 @@ vm_jit_init(rb_vm_t *vm, jit_globals_t globals)
     jit->callbacks.rb_bug_f                 = rb_bug;
     jit->callbacks.vm_exec_core_f           = vm_exec_core;
     jit->callbacks.rb_class2name_f          = rb_class2name;
-    /*
     jit->callbacks.vm_send_woblock_jit_inline_frame_f = vm_send_woblock_jit_inline_frame;
     jit->callbacks.vm_send_woblock_inlineable_guard_f = vm_send_woblock_inlineable_guard;
-    */
     jit->callbacks.rb_threadptr_execute_interrupts_f  = rb_threadptr_execute_interrupts;
 #ifdef OMR_RUBY_VALID_CLASS
     jit->callbacks.ruby_omr_is_valid_object_f                   = rb_omr_is_valid_object;
@@ -153,6 +152,7 @@ vm_jit_init(rb_vm_t *vm, jit_globals_t globals)
     jit->callbacks.rb_str_freeze_f          = rb_str_freeze; 
     jit->callbacks.rb_ivar_set_f            = rb_ivar_set; 
     jit->callbacks.vm_compute_case_dest_f   = vm_compute_case_dest; 
+    jit->callbacks.def_iseq_ptr_f           = def_iseq_ptr; 
 
     verify_jit_callbacks(&jit->callbacks); 
     
@@ -238,7 +238,7 @@ void
 vm_jit_stack_check(rb_thread_t* th, rb_control_frame_t * cfp)
    {
    const VALUE *const bp = vm_base_ptr(cfp);
-   if (cfp->sp != vm_base_ptr(cfp)) 
+   if (cfp->sp != vm_base_ptr(cfp) && !getenv("SKIP_STACK") )
       {
       rb_bug("JIT Stack consistency error (sp: %"PRIdPTRDIFF", bp: %"PRIdPTRDIFF")",
              VM_SP_CNT(th, cfp->sp), VM_SP_CNT(th, bp));


### PR DESCRIPTION
Make the changes required to re-enable the inliner. The inliner now
peeks into the CALL_CACHE associated with a call to decide what to
inline, then guards the inlined bodies with serial number checks.

This means that for the inliner to successfully run, at the iseq must
have run at least once to have filled in the CALL_CACHE.