### PR TITLE
Move most of the compilation control into the JIT

### DIFF
--- a/jit.h
+++ b/jit.h
@@ -151,8 +151,13 @@ struct rb_jit_struct {
    /** Terminate the JIT for the given VM */  
     void  (*terminate_f)(rb_vm_t *vm);
 
-   /** Compile a given instruction sequence */  
-    void* (*compile_f)(const rb_iseq_t *iseq);
+   /**
+    * Compile a given instruction sequence
+    *
+    * Return Qtrue if the body can be excuted 
+    * after return, and Qfalse otherwise.
+    */  
+    VALUE (*compile_f)(rb_iseq_t *iseq);
 
    /** JIT crash Handler  */  
     void (*crash_f)(void);
@@ -177,10 +182,5 @@ void  vm_jit_init   (rb_vm_t *vm, jit_globals_t globals);
  * Destroy the JIT for a VM
  */
 void  vm_jit_destroy(rb_vm_t *vm);
-
-/**
- * Compile an instruction sequence
- */
-void *vm_jit_compile(rb_vm_t *vm, const rb_iseq_t *iseq);
 
 #endif

--- a/jit.h
+++ b/jit.h
@@ -159,6 +159,15 @@ struct rb_jit_struct {
     */  
     VALUE (*compile_f)(rb_iseq_t *iseq);
 
+    /**
+     * Updates the invocation information
+     * for the JIT, potentially triggering or queuing compilation
+     *
+     * Returns Qtrue if the body can be 
+     * executed, and Qfalse otherwise. 
+     */
+    VALUE (*update_state_f)(rb_thread_t*, const rb_iseq_t* iseq); 
+
    /** JIT crash Handler  */  
     void (*crash_f)(void);
 

--- a/rbjitglue/ruby/control/RubyJit.cpp
+++ b/rbjitglue/ruby/control/RubyJit.cpp
@@ -315,9 +315,13 @@ void jit_terminate(rb_vm_t *vm)
    jitTerminate(vm);
    }
 
-void *jit_compile(rb_iseq_t *iseq)
+/**
+ * Return Qtrue if execution can proceed when this function returns. Otherwise, 
+ * return false, and update the iseq jit states. 
+ */
+VALUE jit_compile(rb_iseq_t *iseq)
    {
-   iseq_jit_body_info *body_info = NULL;
+   VALUE has_body_to_execute = Qfalse;
    void *startPC = NULL;
    TR_Hotness optLevel = cold;
 
@@ -354,10 +358,9 @@ void *jit_compile(rb_iseq_t *iseq)
                                         truncated ? "(truncated)" : "",
                                         iseq->jit.body_info->startPC);
 
-      return NULL;
+      has_body_to_execute = Qtrue;
+      goto cleanupAndExit;
       }
-
-   auto &fe = TR_RubyFE::singleton();
 
    if ((iseq->body->param.flags.has_opt
          && feGetEnv("TR_DISABLE_OPTIONAL_ARGUMENTS"))   ||
@@ -389,16 +392,48 @@ void *jit_compile(rb_iseq_t *iseq)
 
    if (startPC)
       {
-      body_info = ALLOC(iseq_jit_body_info);
+      iseq_jit_body_info *body_info =  ALLOC(iseq_jit_body_info);
       assert(body_info && "Failed to allocate body_info");
 
       body_info->opt_level = optLevel;
       body_info->startPC = startPC;
+
+      /* Set up body to prepare for recompilation. 
+       */
+      body_info->recomp_count = TR::Options::getCmdLineOptions()->getInitialCount();
+      body_info->invoke_count = 0;
+      body_info->prev = NULL;
+      body_info->next = iseq->jit.body_info;
+
+      if (iseq->jit.body_info) {
+         iseq->jit.body_info->prev = body_info;
+      }
+
+      iseq->jit.body_info = body_info;
+      iseq->jit.u.code  = body_info->startPC;
+
+      // It will be important the state transition happens last 
+      // when doing asynchronous compilation.
+      iseq->jit.state = ISEQ_JIT_STATE_JITTED;
+      has_body_to_execute= Qtrue;
+      }
+   else 
+      {
+      if (iseq->jit.state == ISEQ_JIT_STATE_JITTED) {
+            /* unable to recompile - never attempt again */
+            iseq->jit.state = ISEQ_JIT_STATE_RECOMP_BLACKLISTED;
+            return Qtrue;
+        }
+        else {
+            /* unable to compile - never attempt again */
+            iseq->jit.state = ISEQ_JIT_STATE_BLACKLISTED;
+            return Qfalse;
+        }
       }
 
 cleanupAndExit:
    free(name);
-   return (void *)body_info;
+   return has_body_to_execute;
    }
 
 

--- a/vm.c
+++ b/vm.c
@@ -1702,8 +1702,8 @@ hook_before_rewind(rb_thread_t *th, rb_control_frame_t *cfp, int will_finish_vm_
 static inline VALUE
 vm_exec2(rb_thread_t *th, VALUE initial)
 {
-    VALUE result;
 #if defined(JIT_OMR)
+    VALUE result;
     /* The OMR JIT is currently not able to support invocations of methods with a
      * frame type of RESCUE.
      *
@@ -1729,12 +1729,13 @@ vm_exec2(rb_thread_t *th, VALUE initial)
         VM_FRAME_FINISHED_P(th->cfp) && 
         vm_jitted_p(th, (rb_iseq_t*)th->cfp->iseq) == Qtrue) {  //Cast away constness for compiler  -- FIXME: May require redesign. 
 	result = vm_exec_jitted(th);
-    }
-    else
-#endif
-	/* warning: dangling else above */
+    } else {
 	result = vm_exec_core(th, initial);
+    }
     return result;
+#else 
+    return vm_exec_core(th, initial);
+#endif
 }
 
 static VALUE

--- a/vm.c
+++ b/vm.c
@@ -3468,7 +3468,7 @@ vm_jit_compile_method(VALUE klass, VALUE method)
 
    if (!NIL_P(iseq)) {
       th   = GET_THREAD();
-      return vm_jit(th, rb_iseqw_to_iseq(iseq));   
+      return th->vm->jit->compile_f(rb_iseqw_to_iseq(iseq));   
    }
 #endif
    return Qfalse; 

--- a/vm_core.h
+++ b/vm_core.h
@@ -282,14 +282,10 @@ typedef enum iseq_type {
 } iseq_type;              /* instruction sequence type */
 
 #if defined(JIT_OMR)
-typedef enum iseq_jit_state {
-    ISEQ_JIT_STATE_ZERO = 0, /* un-initialized */
-    ISEQ_JIT_STATE_INTERPRETED,
-    ISEQ_JIT_STATE_BLACKLISTED, /* don't try to jit */
-    ISEQ_JIT_STATE_RECOMP_BLACKLISTED, /* don't try to recompile */
-    ISEQ_JIT_STATE_JITTED
-} iseq_jit_state;
-
+/** 
+ * A doubly-linked list of information about compiled
+ * methods for a particular iseq. 
+ */
 typedef struct iseq_jit_body_info {
     int opt_level;
     long recomp_count;
@@ -298,6 +294,19 @@ typedef struct iseq_jit_body_info {
     struct iseq_jit_body_info *prev;
     struct iseq_jit_body_info *next;
 } iseq_jit_body_info;
+
+/** 
+ * The JIT related states a method can be in.
+ */
+typedef enum iseq_jit_state {
+    ISEQ_JIT_STATE_ZERO = 0,           /* un-initialized */
+    ISEQ_JIT_STATE_INTERPRETED,        /* JIT info is initialized (count set, etc),
+                                          but still interpreting
+                                        */
+    ISEQ_JIT_STATE_BLACKLISTED,        /* Removed from JIT consideration. */
+    ISEQ_JIT_STATE_RECOMP_BLACKLISTED, /* Removed from recompilation consideration. */
+    ISEQ_JIT_STATE_JITTED              /* A JIT body exists */ 
+} iseq_jit_state;
 #endif
 
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2838,59 +2838,6 @@ vm_defined(rb_thread_t *th, rb_control_frame_t *reg_cfp, rb_num_t op_type, VALUE
 }
 
 #ifdef JIT_INTERFACE 
-/**
- * Compile an iseq. 
- */
-void *
-vm_jit_compile(rb_vm_t *vm, const rb_iseq_t *iseq)
-{
-    assert(   vm->jit
-           && vm->jit->compile_f
-           && "vm_jit_compile should only be called when we have JIT enabled");
-
-    return (vm->jit->compile_f)(iseq);
-}
-
-/*
- * JIT the given iseq. 
- *
- * Return true if successful, and false if not. 
- */
-static VALUE
-vm_jit(rb_thread_t *th, rb_iseq_t * iseq)
-{
-    iseq_jit_body_info *body_info = NULL;;
-    if (!th->vm->jit) return Qfalse; /* Don't compile if we have no jit.  */
-    
-    body_info = (iseq_jit_body_info *)vm_jit_compile(th->vm, iseq);
-    if (body_info) {
-        /* OMR:TODO:GVL: we may need to do the following atomically */
-        
-        body_info->recomp_count = th->vm->jit->default_count;
-        body_info->invoke_count = 0;
-        body_info->prev = NULL;
-        body_info->next = iseq->jit.body_info;
-        if (iseq->jit.body_info) {
-            iseq->jit.body_info->prev = body_info;
-        }
-        iseq->jit.body_info = body_info;
-        iseq->jit.u.code  = body_info->startPC;
-        iseq->jit.state = ISEQ_JIT_STATE_JITTED;
-        return Qtrue; /* jitted now */
-    } else {
-        if (iseq->jit.state == ISEQ_JIT_STATE_JITTED) {
-            /* unable to recompile - never attempt again */
-            iseq->jit.state = ISEQ_JIT_STATE_RECOMP_BLACKLISTED;
-            return Qtrue;
-        }
-        else {
-            /* unable to compile - never attempt again */
-            iseq->jit.state = ISEQ_JIT_STATE_BLACKLISTED;
-            return Qfalse;
-        }
-    }
-}
-
 static VALUE
 vm_jitted_p(rb_thread_t *th, const rb_iseq_t *iseq_const)
 {
@@ -2906,17 +2853,14 @@ vm_jitted_p(rb_thread_t *th, const rb_iseq_t *iseq_const)
     if (iseq->jit.state == ISEQ_JIT_STATE_JITTED) {
         if (th->vm->jit->options & TIERED_COMPILATION) {
             --iseq->jit.body_info->recomp_count;
-            
             if (iseq->jit.body_info->recomp_count < 0) {
-                return vm_jit(th,(rb_iseq_t*)iseq); //Cast away constness if we're compiling 
+                return th->vm->jit->compile_f(iseq);
             }
         }
         return Qtrue;
     }
-    
+   
     if (iseq->jit.state == ISEQ_JIT_STATE_ZERO) {
-        /* uninitialized */
-        /* OMR:TODO:GVL: we may need to do the following atomically */
         iseq->jit.u.count = th->vm->jit->default_count;
         iseq->jit.state = ISEQ_JIT_STATE_INTERPRETED;
         iseq->jit.body_info = NULL;
@@ -2925,7 +2869,7 @@ vm_jitted_p(rb_thread_t *th, const rb_iseq_t *iseq_const)
     --iseq->jit.u.count;
 
     if (iseq->jit.u.count < 0) {
-       return vm_jit(th,iseq); 
+       return th->vm->jit->compile_f(iseq);
     }
     
     return Qfalse; /* not jitted yet */

--- a/vm_jit.c
+++ b/vm_jit.c
@@ -66,18 +66,20 @@ vm_jit_init(rb_vm_t *vm, jit_globals_t globals)
     }
 
     /* vm->jit interface */
-    jit->dll_handle  = handle;
-    jit->default_count = JIT_DEFAULT_COUNT;
-    jit->init_f        = dlsym(handle, "jit_init"); 
-    jit->terminate_f = dlsym(handle, "jit_terminate");
-    jit->compile_f   = dlsym(handle, "jit_compile");
-    jit->dispatch_f  = dlsym(handle, "jit_dispatch");
-    jit->crash_f     = dlsym(handle, "jit_crash");
+    jit->dll_handle     = handle;
+    jit->default_count  = JIT_DEFAULT_COUNT;
+    jit->init_f         = dlsym(handle, "jit_init"); 
+    jit->terminate_f    = dlsym(handle, "jit_terminate");
+    jit->compile_f      = dlsym(handle, "jit_compile");
+    jit->update_state_f = dlsym(handle, "jit_update_state");
+    jit->dispatch_f     = dlsym(handle, "jit_dispatch");
+    jit->crash_f        = dlsym(handle, "jit_crash");
 
-    if (!jit->init_f      ||
-	!jit->terminate_f ||
-	!jit->compile_f   ||
-	!jit->crash_f   ||
+    if (!jit->init_f            ||
+	!jit->terminate_f       ||
+	!jit->compile_f         ||
+	!jit->update_state_f    ||
+	!jit->crash_f           ||
         !jit->dispatch_f   ) {
 	fprintf(stderr, "vm_jit_init: missing symbols in %s: init %p, terminate %p, compile %p, dispatch %p crash %p\n",
                 dll_name,


### PR DESCRIPTION
This PR relocates the compilation control logic, moving the majority of it into the JIT.

This is being done to enable future enhancements to compilation control, most directly #30 